### PR TITLE
add mandatory environment variables to helm value files

### DIFF
--- a/helm/naavre-containerizer-service/values-example.yaml
+++ b/helm/naavre-containerizer-service/values-example.yaml
@@ -15,3 +15,6 @@ conf:
 
 env:
   OIDC_CONFIGURATION_URL: "https://<keycloak-host>/<keycloak-base-path>/realms/<realm>/.well-known/openid-configuration"
+  MODULE_MAPPING_URL: "https://raw.githubusercontent.com/QCDIS/NaaVRE-conf/main/module_mapping.json"
+  CELL_GITHUB: "https://github.com/my-org/my-repo.git"
+  CELL_GITHUB_TOKEN: "my_token"

--- a/helm/naavre-containerizer-service/values.yaml
+++ b/helm/naavre-containerizer-service/values.yaml
@@ -114,3 +114,6 @@ env:
   DEBUG: "false"
   OIDC_CONFIGURATION_URL: ""
   VERIFY_SSL: "true"
+  MODULE_MAPPING_URL: "https://raw.githubusercontent.com/QCDIS/NaaVRE-conf/main/module_mapping.json"
+  CELL_GITHUB: ""
+  CELL_GITHUB_TOKEN: ""


### PR DESCRIPTION
Adds the mandatory environment variables to `helm/naavre-containerizer-service/values.yaml` and `helm/naavre-containerizer-service/values-example.yaml`, so that they can be used as examples for deployment. 